### PR TITLE
fix: prevent nil deref in MinimizeAttributeChanges and run tests with…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # run unit test
 test:
-	go test ./...
+	go test ./... -gcflags="all=-N -l"
 
 # generate coverage statistics.
 cover:

--- a/y_text.go
+++ b/y_text.go
@@ -131,7 +131,7 @@ func MinimizeAttributeChanges(currPos *ItemTextListPosition, attributes Object) 
 		return EqualAttrs(attributes[cf.Key], cf.Value)
 	}
 
-	for currPos.Right.Deleted() || isEqual(currPos.Right.Content, attributes) {
+	for currPos.Right != nil && (currPos.Right.Deleted() || isEqual(currPos.Right.Content, attributes)) {
 		currPos.Forward()
 	}
 }


### PR DESCRIPTION
… debug flags

- Add explicit nil check for currPos.Right before accessing its fields/methods to avoid a potential nil pointer dereference in MinimizeAttributeChanges.
- Tighten loop condition to skip deleted or equal nodes safely.
- Run go test with -gcflags="all=-N -l" in Makefile test target to disable optimizations/inlining for easier debugging.