### PR TITLE
Fix relative position decode, XML element event handlers, and event logging

### DIFF
--- a/relative_position.go
+++ b/relative_position.go
@@ -182,8 +182,10 @@ func ReadRelativePosition(decoder *UpdateDecoderV1) *RelativePosition {
 	var itemID *ID
 	var assoc Number
 
-	n, _ := readVarUint(decoder.RestDecoder)
-	switch n {
+	// Read tag with ReadVarUint (concrete uint64). readVarUint returns any holding
+	// uint64; switch cases 0,1,2 are untyped ints and never match that dynamic type.
+	tag := ReadVarUint(decoder.RestDecoder)
+	switch tag {
 	case 0:
 		// case 1: found position somewhere in the linked list
 		itemID, _ = decoder.ReadID()

--- a/relative_position_test.go
+++ b/relative_position_test.go
@@ -1,0 +1,25 @@
+package y_crdt
+
+import "testing"
+
+func TestDecodeRelativePositionTags(t *testing.T) {
+	itemID := GenID(1, 2)
+	rp0 := &RelativePosition{Item: &itemID, Assoc: 0}
+	dec0 := DecodeRelativePosition(EncodeRelativePosition(rp0))
+	if dec0.Item == nil || dec0.Item.Client != 1 || dec0.Item.Clock != 2 {
+		t.Fatalf("case 0: got item %#v", dec0.Item)
+	}
+
+	rp1 := &RelativePosition{Tname: "XmlText", Assoc: -1}
+	dec1 := DecodeRelativePosition(EncodeRelativePosition(rp1))
+	if dec1.Tname != "XmlText" || dec1.Assoc != -1 {
+		t.Fatalf("case 1: got tname=%q assoc=%v", dec1.Tname, dec1.Assoc)
+	}
+
+	typeID := GenID(3, 4)
+	rp2 := &RelativePosition{Type: &typeID, Assoc: 1}
+	dec2 := DecodeRelativePosition(EncodeRelativePosition(rp2))
+	if dec2.Type == nil || dec2.Type.Client != 3 || dec2.Type.Clock != 4 {
+		t.Fatalf("case 2: got type %#v", dec2.Type)
+	}
+}

--- a/y_event.go
+++ b/y_event.go
@@ -108,7 +108,7 @@ func (y *YEvent) GetKeys() map[string]EventAction {
 							action = ActionDelete
 							oldValue, err = ArrayLast(prev.Content.GetContent())
 							if err != nil {
-								Log("[crdt] %s.", err.Error())
+								Logf("[crdt] %s.", err.Error())
 								return nil
 							}
 						} else {
@@ -119,7 +119,7 @@ func (y *YEvent) GetKeys() map[string]EventAction {
 							action = ActionUpdate
 							oldValue, err = ArrayLast(prev.Content.GetContent())
 							if err != nil {
-								Log("[crdt] %s.", err.Error())
+								Logf("[crdt] %s.", err.Error())
 								return nil
 							}
 						} else {
@@ -132,7 +132,7 @@ func (y *YEvent) GetKeys() map[string]EventAction {
 						action = ActionDelete
 						oldValue, err = ArrayLast(item.Content.GetContent())
 						if err != nil {
-							Log("[crdt] %s.", err.Error())
+							Logf("[crdt] %s.", err.Error())
 							return nil
 						}
 					} else {

--- a/y_xml_element.go
+++ b/y_xml_element.go
@@ -171,8 +171,15 @@ func (y *YXmlElement) Write(encoder *UpdateEncoderV1) {
 	}
 }
 
+// NewYXmlElement creates a Y.XmlElement with its event handlers initialized.
+//
+// EH and DEH must be set before the element is integrated and edited; without
+// them, transaction cleanup dereferences a nil deep-event-handler when a
+// descendant of a previously-committed element is edited.
 func NewYXmlElement(nodeName string) *YXmlElement {
 	el := &YXmlElement{NodeName: nodeName}
 	el.PrelimAttrs = make(map[string]interface{})
+	el.EH = NewEventHandler()
+	el.DEH = NewEventHandler()
 	return el
 }


### PR DESCRIPTION
This PR fixes relative-position decoding, tightens event logging, and ensures new XML elements are safe to edit after integration.

- **Relative position decode** : ReadRelativePosition now reads the wire-format tag with ReadVarUint (concrete uint64) instead of readVarUint (any). Untyped switch cases 0, 1, and 2 never matched a uint64 in an any, so all three tag variants were mis-decoded. Added TestDecodeRelativePositionTags for round-trip encode/decode of item, type-name, and type-ID positions.

- **Event logging**: In YEvent.GetKeys, error paths that use a format string now call Logf instead of Log, so %s is expanded correctly.

- **XML element construction**: NewYXmlElement initializes EH and DEH via NewEventHandler(), avoiding nil dereferences during transaction cleanup when a descendant of an already-committed element is edited.